### PR TITLE
fix: render with fullscreen triangle, WebXR rendering with postprocessing

### DIFF
--- a/src/EffectCompositer.js
+++ b/src/EffectCompositer.js
@@ -22,7 +22,7 @@ const EffectCompositer = {
 		varying vec2 vUv;
 		void main() {
 			vUv = uv;
-			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = vec4(position, 1);
 		}`,
     fragmentShader: /* glsl */ `
 		uniform sampler2D sceneDiffuse;

--- a/src/EffectShader.js
+++ b/src/EffectShader.js
@@ -29,7 +29,7 @@ const EffectShader = {
 varying vec2 vUv;
 void main() {
   vUv = uv;
-  gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+  gl_Position = vec4(position, 1);
 }`,
 
     fragmentShader: /* glsl */ `

--- a/src/FullScreenTriangle.js
+++ b/src/FullScreenTriangle.js
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+
+const _geometry = new THREE.BufferGeometry();
+_geometry.setAttribute(
+	'position',
+	new THREE.BufferAttribute(new Float32Array([-1, -1, 3, -1, -1, 3]), 2)
+);
+_geometry.setAttribute(
+	'uv',
+	new THREE.BufferAttribute(new Float32Array([0, 0, 2, 0, 0, 2]), 2)
+);
+
+// Recent three.js versions break setDrawRange or itemSize <3 position
+_geometry.boundingSphere = new THREE.Sphere()
+_geometry.computeBoundingSphere = () => {}
+
+const _camera = new THREE.OrthographicCamera()
+
+export class FullScreenTriangle {
+	constructor(material) {
+		this._mesh = new THREE.Mesh(_geometry, material);
+		this._mesh.frustumCulled = false;
+	}
+
+	render(renderer) {
+		renderer.render(this._mesh, _camera);
+	}
+
+	get material() {
+		return this._mesh.material;
+	}
+
+	set material(value) {
+		this._mesh.material = value;
+	}
+
+  dispose() {
+		this._mesh.material.dispose();
+		this._mesh.geometry.dispose();
+	}
+}

--- a/src/FullScreenTriangle.js
+++ b/src/FullScreenTriangle.js
@@ -2,40 +2,40 @@ import * as THREE from 'three';
 
 const _geometry = new THREE.BufferGeometry();
 _geometry.setAttribute(
-	'position',
-	new THREE.BufferAttribute(new Float32Array([-1, -1, 3, -1, -1, 3]), 2)
+  'position',
+  new THREE.BufferAttribute(new Float32Array([-1, -1, 3, -1, -1, 3]), 2)
 );
 _geometry.setAttribute(
-	'uv',
-	new THREE.BufferAttribute(new Float32Array([0, 0, 2, 0, 0, 2]), 2)
+  'uv',
+  new THREE.BufferAttribute(new Float32Array([0, 0, 2, 0, 0, 2]), 2)
 );
 
 // Recent three.js versions break setDrawRange or itemSize <3 position
-_geometry.boundingSphere = new THREE.Sphere()
-_geometry.computeBoundingSphere = () => {}
+_geometry.boundingSphere = new THREE.Sphere();
+_geometry.computeBoundingSphere = function() {};
 
 const _camera = new THREE.OrthographicCamera()
 
 export class FullScreenTriangle {
-	constructor(material) {
-		this._mesh = new THREE.Mesh(_geometry, material);
-		this._mesh.frustumCulled = false;
-	}
+  constructor(material) {
+    this._mesh = new THREE.Mesh(_geometry, material);
+    this._mesh.frustumCulled = false;
+  }
 
-	render(renderer) {
-		renderer.render(this._mesh, _camera);
-	}
+  render(renderer) {
+    renderer.render(this._mesh, _camera);
+  }
 
-	get material() {
-		return this._mesh.material;
-	}
+  get material() {
+    return this._mesh.material;
+  }
 
-	set material(value) {
-		this._mesh.material = value;
-	}
+  set material(value) {
+    this._mesh.material = value;
+  }
 
   dispose() {
-		this._mesh.material.dispose();
-		this._mesh.geometry.dispose();
-	}
+    this._mesh.material.dispose();
+    this._mesh.geometry.dispose();
+  }
 }

--- a/src/N8AOPass.js
+++ b/src/N8AOPass.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
-import { Pass, FullScreenQuad } from "three/examples/jsm/postprocessing/Pass.js";
+import { Pass } from "three/examples/jsm/postprocessing/Pass.js";
+import { FullScreenTriangle } from './FullScreenTriangle.js';
 import { EffectShader } from './EffectShader.js';
 import { EffectCompositer } from './EffectCompositer.js';
 import { PoissionBlur } from './PoissionBlur.js';
@@ -96,7 +97,7 @@ class N8AOPass extends Pass {
         /** @type {THREE.Vector2[]} */
         this.samplesDenoise = [];
         this.configureSampleDependentPasses();
-        this.effectCompisterQuad = new FullScreenQuad(new THREE.ShaderMaterial(EffectCompositer));
+        this.effectCompisterQuad = new FullScreenTriangle(new THREE.ShaderMaterial(EffectCompositer));
         this.beautyRenderTarget = new THREE.WebGLRenderTarget(this.width, this.height, {
             minFilter: THREE.LinearFilter,
             magFilter: THREE.NearestFilter
@@ -149,7 +150,7 @@ class N8AOPass extends Pass {
             this.effectShaderQuad.material.dispose();
             this.effectShaderQuad.material = new THREE.ShaderMaterial(e);
         } else {
-            this.effectShaderQuad = new FullScreenQuad(new THREE.ShaderMaterial(e));
+            this.effectShaderQuad = new FullScreenTriangle(new THREE.ShaderMaterial(e));
         }
     }
     configureDenoisePass(logarithmicDepthBuffer = false) {
@@ -163,7 +164,7 @@ class N8AOPass extends Pass {
                 this.poissonBlurQuad.material.dispose();
                 this.poissonBlurQuad.material = new THREE.ShaderMaterial(p);
             } else {
-                this.poissonBlurQuad = new FullScreenQuad(new THREE.ShaderMaterial(p));
+                this.poissonBlurQuad = new FullScreenTriangle(new THREE.ShaderMaterial(p));
             }
         }
         /**

--- a/src/N8AOPass.js
+++ b/src/N8AOPass.js
@@ -249,6 +249,9 @@ class N8AOPass extends Pass {
             renderer.setRenderTarget(this.beautyRenderTarget);
             renderer.render(this.scene, this.camera);
 
+            const xrEnabled = renderer.xr.enabled;
+            renderer.xr.enabled = false;
+
             this.camera.updateMatrixWorld();
             this.effectShaderQuad.material.uniforms["sceneDiffuse"].value = this.beautyRenderTarget.texture;
             this.effectShaderQuad.material.uniforms["sceneDepth"].value = this.beautyRenderTarget.depthTexture;
@@ -323,6 +326,8 @@ class N8AOPass extends Pass {
                 gl.endQuery(ext.TIME_ELAPSED_EXT);
                 checkTimerQuery(timerQuery, gl, this);
             }
+
+            renderer.xr.enabled = xrEnabled;
         }
         /**
          * Enables the debug mode of the AO, meaning the lastTime value will be updated.

--- a/src/N8AOPostPass.js
+++ b/src/N8AOPostPass.js
@@ -246,6 +246,9 @@ class N8AOPostPass extends Pass {
         this.depthTexture = depthTexture;
     }
     render(renderer, inputBuffer, outputBuffer) {
+            const xrEnabled = renderer.xr.enabled;
+            renderer.xr.enabled = false;
+
             // Copy inputBuffer to outputBuffer
             //renderer.setRenderTarget(outputBuffer);
             //  this.copyQuad.material.uniforms.tDiffuse.value = inputBuffer.texture;
@@ -348,6 +351,8 @@ class N8AOPostPass extends Pass {
                 gl.endQuery(ext.TIME_ELAPSED_EXT);
                 checkTimerQuery(timerQuery, gl, this);
             }
+
+            renderer.xr.enabled = xrEnabled;
         }
         /**
          * Enables the debug mode of the AO, meaning the lastTime value will be updated.

--- a/src/N8AOPostPass.js
+++ b/src/N8AOPostPass.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import { FullScreenQuad } from "three/examples/jsm/postprocessing/Pass.js";
 import { Pass } from "postprocessing";
+import { FullScreenTriangle } from "./FullScreenTriangle.js";
 import { EffectShader } from './EffectShader.js';
 import { EffectCompositer } from './EffectCompositer.js';
 import { PoissionBlur } from './PoissionBlur.js';
@@ -100,8 +100,8 @@ class N8AOPostPass extends Pass {
         /** @type {THREE.Vector2[]} */
         this.samplesDenoise = [];
         this.configureSampleDependentPasses();
-        this.effectCompisterQuad = new FullScreenQuad(new THREE.ShaderMaterial(EffectCompositer));
-        this.copyQuad = new FullScreenQuad(new THREE.ShaderMaterial({
+        this.effectCompisterQuad = new FullScreenTriangle(new THREE.ShaderMaterial(EffectCompositer));
+        this.copyQuad = new FullScreenTriangle(new THREE.ShaderMaterial({
             uniforms: {
                 tDiffuse: {
                     value: null
@@ -111,7 +111,7 @@ class N8AOPostPass extends Pass {
             varying vec2 vUv;
             void main() {
                 vUv = uv;
-                gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+                gl_Position = vec4(position, 1);
             }
             `,
             fragmentShader: `
@@ -168,7 +168,7 @@ class N8AOPostPass extends Pass {
             this.effectShaderQuad.material.dispose();
             this.effectShaderQuad.material = new THREE.ShaderMaterial(e);
         } else {
-            this.effectShaderQuad = new FullScreenQuad(new THREE.ShaderMaterial(e));
+            this.effectShaderQuad = new FullScreenTriangle(new THREE.ShaderMaterial(e));
         }
     }
     configureDenoisePass(logarithmicDepthBuffer = false) {
@@ -182,7 +182,7 @@ class N8AOPostPass extends Pass {
                 this.poissonBlurQuad.material.dispose();
                 this.poissonBlurQuad.material = new THREE.ShaderMaterial(p);
             } else {
-                this.poissonBlurQuad = new FullScreenQuad(new THREE.ShaderMaterial(p));
+                this.poissonBlurQuad = new FullScreenTriangle(new THREE.ShaderMaterial(p));
             }
         }
         /**

--- a/src/PoissionBlur.js
+++ b/src/PoissionBlur.js
@@ -28,7 +28,7 @@ const PoissionBlur = {
 		varying vec2 vUv;
 		void main() {
 			vUv = uv;
-			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = vec4(position, 1.0);
 		}`,
     fragmentShader: /* glsl */ `
 		uniform sampler2D sceneDiffuse;


### PR DESCRIPTION
Uses a fullscreen triangle like postprocessing to ignore camera transforms for effects. This enables WebXR rendering where three.js will break camera transforms.

https://twitter.com/Cody_J_Bennett/status/1662847723463213058