### PR TITLE
Fix HALFRES compositer darkening background behind transparent geometry

### DIFF
--- a/src/EffectCompositer.js
+++ b/src/EffectCompositer.js
@@ -177,7 +177,7 @@ const EffectCompositer = {
         #ifdef HALFRES 
         vec4 texel;
         if (depth == 1.0) {
-            texel = vec4(0.0, 0.0, 0.0, 1.0);
+            texel = texture2D(tDiffuse, vUv);
         } else {
         vec3 worldPos = getWorldPos(depth, vUv);
         vec3 normal = computeNormal(getWorldPos(depth, vUv), vUv);


### PR DESCRIPTION
## Problem

When `halfRes` is enabled, the EffectCompositer's HALFRES code path hardcodes `vec4(0.0, 0.0, 0.0, 1.0)` for far-plane pixels (`depth == 1.0`). The R channel value of `0.0` is interpreted as full ambient occlusion, which darkens the entire background when transparent objects with `depthWrite` disabled leave far-plane depth values in the depth buffer.

## Fix

Replace the hardcoded constant with `texture2D(tDiffuse, vUv)`, which bilinearly samples the AO buffer. For background pixels the AO pass already writes `1.0` (no occlusion) via the early return in the EffectShader, so the sampled value is correct. This also provides smooth edge transitions at geometry boundaries — the hardcoded constant created a visible halo where the binary `depth == 1.0` check met the upsampled AO values.

## Reproduction

1. Render a scene with `halfRes: true`
2. Set some geometry to transparent with `depthWrite: false`
3. Observe the background behind transparent geometry is darkened
4. With `halfRes: false`, the background renders correctly

## Change

One-line change in `src/EffectCompositer.js`:

```diff
-            texel = vec4(0.0, 0.0, 0.0, 1.0);
+            texel = texture2D(tDiffuse, vUv);
```